### PR TITLE
chore(ci): update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -23,7 +23,7 @@ jobs:
       IRECEIPTPRO_API_KEY: ${{ secrets.IRECEIPTPRO_API_KEY }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: main
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,7 +44,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch || github.ref }}
           fetch-depth: 1

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,13 +17,13 @@ jobs:
       NODE_VERSION: 24
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Cache node modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -34,7 +34,7 @@ jobs:
       - name: Run builder
         run: npm run build
       - name: Archive build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: ${{ github.workspace }}/dist
@@ -50,9 +50,9 @@ jobs:
       IRECEIPTPRO_API_KEY: ${{ secrets.IRECEIPTPRO_API_KEY }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: dist
           path: ${{ github.workspace }}/dist
@@ -61,7 +61,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Cache node modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/release-on-version-bump.yml
+++ b/.github/workflows/release-on-version-bump.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update GitHub Actions to their latest versions:

- `actions/checkout` v5 → **v6** (improved credential security)
- `actions/cache` v4 → **v5** (new cache backend with better performance)
- `actions/upload-artifact` v4 → **v7** (Node.js 24 runtime)
- `actions/download-artifact` v4 → **v7** (Node.js 24 runtime)

All 4 workflow files updated: `autoupdate.yml`, `claude.yml`, `pr-checks.yml`, `release-on-version-bump.yml`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZFzpa3MNzjh4kXkF3oLWV)_