### PR TITLE
chore(ci): pr-checks on push, assign autoupdate PRs to maintainer

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -123,7 +123,9 @@ jobs:
             --base main \
             --head "$AUTOUPDATE_BRANCH" \
             --title "chore(deps): autoupdate v${{ steps.pkg.outputs.version }}" \
-            --body "$BODY")
+            --body "$BODY" \
+            --assignee siarheidudko \
+            --reviewer siarheidudko)
           echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
       - name: Open draft PR (autoupdater failed)
         id: pr_failure
@@ -152,7 +154,9 @@ jobs:
             --head "$AUTOUPDATE_BRANCH" \
             --title "chore(deps): autoupdate (needs claude fix)" \
             --body "$BODY" \
-            --draft)
+            --draft \
+            --assignee siarheidudko \
+            --reviewer siarheidudko)
           echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
       - name: Trigger PR checks (GITHUB_TOKEN can't auto-trigger pull_request)
         if: steps.pr_success.outputs.pr_url != '' || steps.pr_failure.outputs.pr_url != ''

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,9 +2,11 @@ name: PR checks
 on:
   pull_request:
     branches: [main]
+  push:
+    branches-ignore: [main]
   workflow_dispatch:
 concurrency:
-  group: "${{ github.workflow }} @ ${{ github.ref }}"
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.ref || github.ref }}"
   cancel-in-progress: true
 permissions:
   contents: read


### PR DESCRIPTION
Two CI/triage improvements:

**1. `pr-checks.yml` now triggers on `push` to feature branches**
Previously only `pull_request` (opened/synchronize/reopened) fired tests, which meant pushes by `GITHUB_TOKEN` (autoupdate, claude.yml) silently skipped CI. Now any push to a non-main branch runs the build/test pipeline. Concurrency group updated to dedupe push + pull_request events on the same branch.

**2. `autoupdate.yml` assigns and requests review from `siarheidudko` on auto-created PRs**
Both the success and failure PR-create paths now include `--assignee siarheidudko --reviewer siarheidudko` so PRs surface in your GitHub dashboard immediately instead of getting buried.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZFzpa3MNzjh4kXkF3oLWV)_