### PR TITLE
fix(autoupdate): robust wait-for-checks logic before merge

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -171,12 +171,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ steps.pr_success.outputs.pr_url }}
         run: |
-          for i in $(seq 1 10); do
-            COUNT=$(gh pr checks "$PR_URL" 2>/dev/null | grep -c '\S' || true)
+          for i in $(seq 1 20); do
+            COUNT=$(gh pr checks "$PR_URL" 2>/dev/null | grep -cE 'https?://' || true)
             [ "$COUNT" -gt 0 ] && break
             sleep 30
           done
-          gh pr checks "$PR_URL" --watch
+          gh pr checks "$PR_URL" --watch || true
+          gh pr checks "$PR_URL" 2>/dev/null | grep -qE '\s+fail\b' && { echo "checks failed"; exit 1; }
           gh pr merge "$PR_URL" --squash --delete-branch
       - name: Tag release commit and dispatch deploy
         if: steps.merge_pr.outcome == 'success' && steps.pkg.outputs.version != ''


### PR DESCRIPTION
## Summary

- Fix false-positive exit from the "wait for checks" loop: `grep -c '\S'` matched the `"no checks reported on the '...' branch"` message before any real check runs were registered, causing the loop to break prematurely
- Replace with `grep -cE 'https?://'` — only actual check run entries contain a URL
- Add `|| true` after `gh pr checks --watch` to prevent step abort on non-zero exit
- Add explicit failure gate before merge
- Increase polling retries from 10 to 20

## Test plan

- [ ] Merge this PR to main
- [ ] Verify next autoupdate run auto-merges the PR after checks pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFifTGBh7g8gEi1ucWJixS)_