### PR TITLE
Add project overview, design-system and related-repos sections to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,46 @@
 
 Library for creating PDF files or images from HTML templates via the iReceipt.pro service. Published to npm as `@ireceipt.pro/js`.
 
+**Role in the project:** the official client SDK — a thin typed wrapper around the REST API (`api` function) for generating PDF/JPG/PNG/WEBP from templates. Published to npm as `@ireceipt.pro/js`.
+
+## About iReceipt.pro
+
+iReceipt.pro is a low-code SaaS for generating PDF files and JPG / PNG / WEBP images from HTML (Mustache) templates via a REST API. Users design templates, issue API tokens, whitelist domains and manage subscriptions in a web dashboard; rendering is performed by Firebase Cloud Functions (Puppeteer + Sharp).
+
+Live services:
+
+- <https://ireceipt.pro> — marketing landing
+- <https://dashboard.ireceipt.pro> — user dashboard (templates, tokens, billing, sandbox)
+- <https://api.ireceipt.pro> — REST API and Swagger docs
+- <https://status.ireceipt.pro> — public status page
+
+## Design system
+
+The shared design system lives in [`ireceipt-pro/design`](https://github.com/ireceipt-pro/design):
+
+- `design-system.html` — full styleguide: palette, typography, spacing, components, section layouts
+- `tokens.css` — design tokens as CSS custom properties (single source of truth)
+
+The landing page ([`ireceipt-pro/landing`](https://github.com/ireceipt-pro/landing), <https://ireceipt.pro>) is the reference implementation.
+
+Key tokens: brand blue `#0691CA` / dark navy `#004883` (from the logo), amber CTA `#F59E0B`, neutral "ink" scale `#0B1B2B`…`#EEF2F6`, success `#16A34A`, error `#DC2626`; fonts — Manrope (display/headings, 700/800), Inter (body, 400/500/600), JetBrains Mono (code); radii 6/10/16 px; 4 px spacing scale; 1200 px container.
+
+Any user-facing UI in this project MUST follow these tokens — do not introduce ad-hoc colors or fonts.
+
+## Related repositories
+
+| Repo | Role |
+| --- | --- |
+| [`ireceipt-pro/design`](https://github.com/ireceipt-pro/design) | Design system: tokens + styleguide |
+| [`ireceipt-pro/landing`](https://github.com/ireceipt-pro/landing) | Marketing site (<https://ireceipt.pro>), design-system reference implementation |
+| [`ireceipt-pro/dashboard`](https://github.com/ireceipt-pro/dashboard) | React user dashboard (<https://dashboard.ireceipt.pro>) |
+| [`ireceipt-pro/api`](https://github.com/ireceipt-pro/api) | Swagger / OpenAPI docs hosting (<https://api.ireceipt.pro>); `/v1/**` is rewritten to the `api` cloud function |
+| [`ireceipt-pro/status`](https://github.com/ireceipt-pro/status) | Public status page (<https://status.ireceipt.pro>) |
+| [`ireceipt-pro/functions`](https://github.com/ireceipt-pro/functions) | Firebase Cloud Functions backend: rendering API, dashboard callables, webhooks, triggers |
+| [`ireceipt-pro/firebase`](https://github.com/ireceipt-pro/firebase) | Firebase project config: hosting targets, security rules, indexes, emulators |
+| [`ireceipt-pro/service`](https://github.com/ireceipt-pro/service) | Placeholder for the `service` hosting target (webhooks; logic lives in `functions`) |
+| [`ireceipt-pro/js`](https://github.com/ireceipt-pro/js) | Official JS/TS SDK — [`@ireceipt.pro/js`](https://www.npmjs.com/package/@ireceipt.pro/js) on npm |
+
 ## Stack
 
 - TypeScript (`tsc`), targeting CJS + ESM dual build with type declarations.


### PR DESCRIPTION
## Summary

- `CLAUDE.md`: added the SDK's role in the project, an "About iReceipt.pro" overview, design-system links (`ireceipt-pro/design`) and the related-repositories table. All existing instructions (stack, commands, definition of done, boundaries, autoupdate/CI notes) are unchanged.

Docs-only change — no code, build or workflow files touched, so the `npm run build && npm test` gate was not run (it would also require `IRECEIPTPRO_API_KEY` for the integration tests).

https://claude.ai/code/session_01PfoRp1sMvkjDJrRx1WEC3L

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfoRp1sMvkjDJrRx1WEC3L)_