### PR TITLE
ci: judge each check by its newest run

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -204,7 +204,13 @@ jobs:
           # the previous step dispatched explicitly.
           SHA=$(gh pr view "$PR_URL" --json headRefOid --jq .headRefOid)
           for i in $(seq 1 40); do
-            RUNS=$(gh api "repos/$GITHUB_REPOSITORY/commits/$SHA/check-runs" --jq .check_runs)
+            ALL=$(gh api "repos/$GITHUB_REPOSITORY/commits/$SHA/check-runs" --jq .check_runs)
+            # Keep only the newest run of each check name. A check can appear
+            # several times on one commit: autoupdate dispatches CI, then
+            # claude.yml dispatches it again, and pr-checks' concurrency group
+            # cancels the earlier one. Those cancelled leftovers are not a
+            # verdict on the code, but counting them lost a fully green PR.
+            RUNS=$(jq 'group_by(.name) | map(max_by(.id))' <<<"$ALL")
             TOTAL=$(jq length <<<"$RUNS")
             PENDING=$(jq '[.[] | select(.status != "completed")] | length' <<<"$RUNS")
             [ "$TOTAL" -gt 0 ] && [ "$PENDING" -eq 0 ] && break

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -141,7 +141,13 @@ jobs:
           # produces no check runs, so this view sees only jobs that really ran.
           SHA=$(gh pr view "$PR_URL" --json headRefOid --jq .headRefOid)
           for i in $(seq 1 40); do
-            RUNS=$(gh api "repos/$GITHUB_REPOSITORY/commits/$SHA/check-runs" --jq .check_runs)
+            ALL=$(gh api "repos/$GITHUB_REPOSITORY/commits/$SHA/check-runs" --jq .check_runs)
+            # Keep only the newest run of each check name. A check can appear
+            # several times on one commit: autoupdate dispatches CI, then
+            # claude.yml dispatches it again, and pr-checks' concurrency group
+            # cancels the earlier one. Those cancelled leftovers are not a
+            # verdict on the code, but counting them lost a fully green PR.
+            RUNS=$(jq 'group_by(.name) | map(max_by(.id))' <<<"$ALL")
             TOTAL=$(jq length <<<"$RUNS")
             PENDING=$(jq '[.[] | select(.status != "completed")] | length' <<<"$RUNS")
             [ "$TOTAL" -gt 0 ] && [ "$PENDING" -eq 0 ] && break


### PR DESCRIPTION
Rolls out from `siarheidudko/claude#8`.

## Problem

The merge gate refused to merge PRs whose checks were actually green — **#37 was the casualty here**. Claude found nothing to fix, the winning CI run was green on all four checks, and the gate still logged:

```
checks: total=8 pending=0 failed=3
leaving the PR open for review: checks are not green
```

`autoupdate.yml` dispatches CI, then `claude.yml` dispatches it again. Both are `workflow_dispatch` on the same branch, so they land in the same `pr-checks` concurrency group and the second cancels the first. The cancelled check runs stay attached to the commit, and the gate — which read every check run for the SHA — scored them as failures. Eight runs on that commit: four green from the winning dispatch, four leftovers (one green Build, three cancelled) from the superseded one.

## Fix

The gate keeps only the newest run of each check name before judging:

```
group_by(.name) | map(max_by(.id))
```

Applied in both `autoupdate.yml` and `claude.yml`. Verified against a fixture built from #37's real check runs: `total=8 failed=3` becomes `total=4 pending=0 failed=0`, while a genuine later `failure` on the same name is still counted.

Generated from the `siarheidudko/claude` templates; no repo-specific hand edits.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfHHX2WrotHCt9djnk6tMZ)_